### PR TITLE
Fix large upload crash, add markdown download format

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "OneFile",
+  "short_name": "OneFile",
+  "description": "ChatGPT limits you to 3 files? Combine unlimited files into one and upload to any AI. Free, no account, works with PDFs, code, docs.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/src/components/ToolSection.tsx
+++ b/src/components/ToolSection.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Copy, FileText, Download } from "lucide-react";
+import { Copy, FileText, Download, ChevronDown, File } from "lucide-react";
 import Sparkles from "@/components/icons/Sparkles";
 import { FileUpload } from "@/components/FileUpload";
 import { FileList } from "@/components/FileList";
@@ -11,6 +11,12 @@ import { cn, formatBytes } from "@/lib/utils";
 import { GitHubImportDialog } from "@/components/GitHubImportDialog";
 import { TextContentDialog } from "@/components/TextContentDialog";
 import { PostSuccessCard } from "@/components/PostSuccessCard";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { useFileManager } from "@/hooks/useFileManager";
 import { usePromptOutput } from "@/hooks/usePromptOutput";
 import { useGitHubBrowser } from "@/hooks/useGitHubBrowser";
@@ -167,16 +173,42 @@ export function ToolSection() {
                     <Copy className="h-4 w-4 mr-2" />
                     Copy To Clipboard
                   </Button>
-                  <Button
-                    className={cn(
-                      "flex-1 bg-primary text-white hover:text-white hover:bg-primary/95 shadow-sm h-10 sm:h-11 rounded-lg font-medium"
-                    )}
-                    onClick={triggerDownload}
-                    variant="outline"
-                  >
-                    <Download className="h-4 w-4 mr-2" />
-                    Download
-                  </Button>
+                  <div className="flex-1 flex">
+                    <Button
+                      className="flex-1 bg-primary text-white hover:text-white hover:bg-primary/95 shadow-sm h-10 sm:h-11 rounded-l-lg rounded-r-none border-none font-medium focus-visible:ring-0 focus-visible:ring-offset-0"
+                      onClick={() => triggerDownload("txt")}
+                      variant="outline"
+                    >
+                      <Download className="h-4 w-4 mr-2" />
+                      Download .txt
+                    </Button>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          className="bg-primary text-white hover:text-white hover:bg-primary/95 shadow-sm h-10 sm:h-11 rounded-l-none rounded-r-lg border-l border-white/20 border-y-0 border-r-0 px-2 font-medium ring-0 ring-offset-0 focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0 outline-none transition-none"
+                          variant="outline"
+                        >
+                          <ChevronDown className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end" className="w-fit space-y-1 p-2">
+                        <DropdownMenuItem
+                          onClick={() => triggerDownload("txt")}
+                          className="flex items-center gap-2.5 cursor-pointer text-muted-foreground"
+                        >
+                          <File className="h-4 w-4" />
+                          Download as .txt
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={() => triggerDownload("md")}
+                          className="flex items-center gap-2.5 cursor-pointer text-muted-foreground"
+                        >
+                          <FileText className="h-4 w-4" />
+                          Download as .md
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
                 </div>
               )}
             </div>

--- a/src/components/ToolSection.tsx
+++ b/src/components/ToolSection.tsx
@@ -7,7 +7,7 @@ import { Copy, FileText, Download } from "lucide-react";
 import Sparkles from "@/components/icons/Sparkles";
 import { FileUpload } from "@/components/FileUpload";
 import { FileList } from "@/components/FileList";
-import { cn } from "@/lib/utils";
+import { cn, formatBytes } from "@/lib/utils";
 import { GitHubImportDialog } from "@/components/GitHubImportDialog";
 import { TextContentDialog } from "@/components/TextContentDialog";
 import { PostSuccessCard } from "@/components/PostSuccessCard";
@@ -22,8 +22,16 @@ const IMPORT_SOURCES = ["text content", "public GitHub repos"];
 export function ToolSection() {
   const { files, handleFiles, removeFile, clearAllFiles, handleGitHubImport } =
     useFileManager();
-  const { finalPrompt, copyToClipboard, triggerDownload, executeDownload, downloadRequested } =
-    usePromptOutput(files);
+  const {
+    finalPrompt,
+    outputSize,
+    isTruncated,
+    fileCount,
+    copyToClipboard,
+    triggerDownload,
+    executeDownload,
+    downloadRequested,
+  } = usePromptOutput(files);
   const {
     isGitHubBrowserOpen,
     setIsGitHubBrowserOpen,
@@ -133,12 +141,22 @@ export function ToolSection() {
             </div>
 
             <div className="space-y-4 sm:space-y-6">
-              <ScrollArea className="h-[300px] sm:h-[400px] rounded-xl border border-border bg-muted/30 p-4 sm:p-6">
-                <pre className="text-xs sm:text-sm whitespace-pre-wrap font-mono text-foreground leading-relaxed">
-                  {finalPrompt ||
-                    "Your one file (extracted content from your files) will appear here..."}
-                </pre>
-              </ScrollArea>
+              <div className="h-[300px] sm:h-[400px] rounded-xl border border-border bg-muted/30 flex flex-col">
+                <ScrollArea className="flex-1 min-h-0">
+                  <div className="p-4 sm:p-6">
+                    <pre className="text-xs sm:text-sm whitespace-pre-wrap break-all font-mono text-foreground leading-relaxed">
+                      {finalPrompt ||
+                        "Your one file (extracted content from your files) will appear here..."}
+                    </pre>
+                  </div>
+                </ScrollArea>
+                {isTruncated && (
+                  <p className="shrink-0 text-xs text-muted-foreground text-center border-t border-border px-4 py-2">
+                    Showing preview. Full output: {formatBytes(outputSize)},{" "}
+                    {fileCount} file{fileCount === 1 ? "" : "s"}
+                  </p>
+                )}
+              </div>
 
               {finalPrompt && (
                 <div className="flex flex-col sm:flex-row gap-3">

--- a/src/components/ToolSection.tsx
+++ b/src/components/ToolSection.tsx
@@ -149,8 +149,8 @@ export function ToolSection() {
             <div className="space-y-4 sm:space-y-6">
               <div className="h-[300px] sm:h-[400px] rounded-xl border border-border bg-muted/30 flex flex-col">
                 <ScrollArea className="flex-1 min-h-0">
-                  <div className="p-4 sm:p-6">
-                    <pre className="text-xs sm:text-sm whitespace-pre-wrap break-all font-mono text-foreground leading-relaxed">
+                  <div className="p-4 sm:p-6 overflow-hidden">
+                    <pre className="text-xs sm:text-sm whitespace-pre-wrap font-mono text-foreground leading-relaxed [overflow-wrap:anywhere]">
                       {finalPrompt ||
                         "Your one file (extracted content from your files) will appear here..."}
                     </pre>

--- a/src/hooks/useFileManager.ts
+++ b/src/hooks/useFileManager.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { toast } from "react-hot-toast";
 import { FileWithContent } from "@/types";
 import {
@@ -12,6 +12,7 @@ import {
   getUniquePath,
 } from "@/utils/files";
 import { IGNORED_PATHS } from "@/constants/files";
+import { saveFiles, loadFiles, clearFiles } from "@/lib/fileStorage";
 
 interface UseFileManagerReturn {
   files: FileWithContent[];
@@ -23,38 +24,46 @@ interface UseFileManagerReturn {
 
 export function useFileManager(): UseFileManagerReturn {
   const [files, setFiles] = useState<FileWithContent[]>([]);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Restore files from sessionStorage on mount (after OAuth redirect)
+  // Restore files from IndexedDB on mount (after OAuth redirect or page refresh)
   useEffect(() => {
-    try {
-      const savedFiles = sessionStorage.getItem("onefile-temp-files");
-      if (savedFiles) {
-        const parsed = JSON.parse(savedFiles) as FileWithContent[];
-        if (Array.isArray(parsed) && parsed.length > 0) {
-          setFiles(parsed);
+    loadFiles()
+      .then((restored) => {
+        if (restored) {
+          setFiles(restored);
           toast.success(
-            `Restored ${parsed.length} file${parsed.length === 1 ? "" : "s"}`
+            `Restored ${restored.length} file${restored.length === 1 ? "" : "s"}`
           );
+          clearFiles().catch(console.error);
         }
-        sessionStorage.removeItem("onefile-temp-files");
-      }
-    } catch (error) {
-      console.error("Failed to restore files from sessionStorage:", error);
-      sessionStorage.removeItem("onefile-temp-files");
-    }
+      })
+      .catch((error) => {
+        console.error("Failed to restore files from IndexedDB:", error);
+        clearFiles().catch(console.error);
+      });
   }, []);
 
-  // Save files to sessionStorage whenever they change
+  // Save files to IndexedDB whenever they change (debounced)
   useEffect(() => {
-    try {
-      if (files.length === 0) {
-        sessionStorage.removeItem("onefile-temp-files");
-      } else {
-        sessionStorage.setItem("onefile-temp-files", JSON.stringify(files));
-      }
-    } catch (error) {
-      console.error("Failed to sync files to sessionStorage:", error);
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
     }
+
+    if (files.length === 0) {
+      clearFiles().catch(console.error);
+      return;
+    }
+
+    debounceRef.current = setTimeout(() => {
+      saveFiles(files).catch(console.error);
+    }, 1000);
+
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
   }, [files]);
 
   const handleFiles = async (fileList: FileList | null): Promise<void> => {
@@ -307,6 +316,7 @@ export function useFileManager(): UseFileManagerReturn {
 
   const clearAllFiles = (): void => {
     setFiles([]);
+    clearFiles().catch(console.error);
   };
 
   const handleGitHubImport = (

--- a/src/hooks/useGitHubBrowser.ts
+++ b/src/hooks/useGitHubBrowser.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { useUser, useClerk, useAuth } from "@clerk/nextjs";
 import { FileWithContent } from "@/types";
+import { saveFiles } from "@/lib/fileStorage";
 
 interface UseGitHubBrowserReturn {
   isGitHubBrowserOpen: boolean;
@@ -40,13 +41,11 @@ export function useGitHubBrowser(files: FileWithContent[]): UseGitHubBrowserRetu
   }, [isSignedIn]);
 
   const handleSignInClick = (): void => {
-    // Explicitly save files before OAuth redirect (extra safety)
+    // Save files to IndexedDB before OAuth redirect (extra safety)
     if (files.length > 0) {
-      try {
-        sessionStorage.setItem("onefile-temp-files", JSON.stringify(files));
-      } catch (error) {
+      saveFiles(files).catch((error) => {
         console.error("Failed to save files before sign-in:", error);
-      }
+      });
     }
   };
 

--- a/src/hooks/usePromptOutput.ts
+++ b/src/hooks/usePromptOutput.ts
@@ -3,39 +3,95 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { toast } from "react-hot-toast";
 import { FileWithContent } from "@/types";
-import { generatePromptText } from "@/utils/files";
+import {
+  generatePromptText,
+  generatePromptBlob,
+  calculateOutputSize,
+} from "@/utils/files";
+import { formatBytes } from "@/lib/utils";
+
+const PREVIEW_LIMIT = 50_000; // ~50KB preview
+const COPY_SIZE_LIMIT = 100 * 1024 * 1024; // 100MB safety guard for clipboard
 
 interface UsePromptOutputReturn {
   finalPrompt: string;
+  outputSize: number;
+  isTruncated: boolean;
+  fileCount: number;
   copyToClipboard: () => void;
   triggerDownload: () => void;
   executeDownload: () => void;
   downloadRequested: number;
 }
 
-export function usePromptOutput(files: FileWithContent[]): UsePromptOutputReturn {
+function buildPreview(files: FileWithContent[], limit: number): string {
+  let result = "======== FILES ========\n";
+  for (const file of files) {
+    const entry = `*** ${file.path} ***\n${file.content}\n\n`;
+    if (result.length + entry.length > limit) {
+      const remaining = limit - result.length;
+      if (remaining > 0) {
+        result += entry.substring(0, remaining);
+      }
+      break;
+    }
+    result += entry;
+  }
+  return result + "\n...";
+}
+
+export function usePromptOutput(
+  files: FileWithContent[]
+): UsePromptOutputReturn {
   const [finalPrompt, setFinalPrompt] = useState("");
+  const [outputSize, setOutputSize] = useState(0);
+  const [isTruncated, setIsTruncated] = useState(false);
   const [downloadRequested, setDownloadRequested] = useState(0);
+
+  const filesRef = useRef(files);
+  filesRef.current = files;
 
   useEffect(() => {
     if (files.length > 0) {
-      const result = generatePromptText(files);
-      setFinalPrompt(result);
+      const size = calculateOutputSize(files);
+      setOutputSize(size);
+
+      if (size <= PREVIEW_LIMIT) {
+        setFinalPrompt(generatePromptText(files));
+        setIsTruncated(false);
+      } else {
+        setFinalPrompt(buildPreview(files, PREVIEW_LIMIT));
+        setIsTruncated(true);
+      }
     } else {
       setFinalPrompt("");
+      setOutputSize(0);
+      setIsTruncated(false);
     }
   }, [files]);
 
-  const finalPromptRef = useRef(finalPrompt);
-  finalPromptRef.current = finalPrompt;
-
   const copyToClipboard = useCallback((): void => {
-    navigator.clipboard
-      .writeText(finalPromptRef.current)
-      .then(() => {
-        toast.success("Copied to clipboard!");
-      })
-      .catch(() => toast.error("Failed to copy to clipboard"));
+    const currentFiles = filesRef.current;
+    const size = calculateOutputSize(currentFiles);
+
+    if (size > COPY_SIZE_LIMIT) {
+      toast.error(
+        `Output too large to copy (${formatBytes(size)}). Use Download instead.`
+      );
+      return;
+    }
+
+    try {
+      const text = generatePromptText(currentFiles);
+      navigator.clipboard
+        .writeText(text)
+        .then(() => {
+          toast.success("Copied to clipboard!");
+        })
+        .catch(() => toast.error("Failed to copy to clipboard"));
+    } catch {
+      toast.error("Output too large to copy. Use Download instead.");
+    }
   }, []);
 
   const triggerDownload = useCallback((): void => {
@@ -43,7 +99,7 @@ export function usePromptOutput(files: FileWithContent[]): UsePromptOutputReturn
   }, []);
 
   const executeDownload = useCallback((): void => {
-    const blob = new Blob([finalPromptRef.current], { type: "text/plain" });
+    const blob = generatePromptBlob(filesRef.current);
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
@@ -56,6 +112,9 @@ export function usePromptOutput(files: FileWithContent[]): UsePromptOutputReturn
 
   return {
     finalPrompt,
+    outputSize,
+    isTruncated,
+    fileCount: files.length,
     copyToClipboard,
     triggerDownload,
     executeDownload,

--- a/src/hooks/usePromptOutput.ts
+++ b/src/hooks/usePromptOutput.ts
@@ -6,6 +6,7 @@ import { FileWithContent } from "@/types";
 import {
   generatePromptText,
   generatePromptBlob,
+  generateMarkdownBlob,
   calculateOutputSize,
 } from "@/utils/files";
 import { formatBytes } from "@/lib/utils";
@@ -13,13 +14,15 @@ import { formatBytes } from "@/lib/utils";
 const PREVIEW_LIMIT = 50_000; // ~50KB preview
 const COPY_SIZE_LIMIT = 100 * 1024 * 1024; // 100MB safety guard for clipboard
 
+export type DownloadFormat = "txt" | "md";
+
 interface UsePromptOutputReturn {
   finalPrompt: string;
   outputSize: number;
   isTruncated: boolean;
   fileCount: number;
   copyToClipboard: () => void;
-  triggerDownload: () => void;
+  triggerDownload: (format?: DownloadFormat) => void;
   executeDownload: () => void;
   downloadRequested: number;
 }
@@ -50,6 +53,8 @@ export function usePromptOutput(
 
   const filesRef = useRef(files);
   filesRef.current = files;
+
+  const pendingFormatRef = useRef<DownloadFormat>("txt");
 
   useEffect(() => {
     if (files.length > 0) {
@@ -94,16 +99,27 @@ export function usePromptOutput(
     }
   }, []);
 
-  const triggerDownload = useCallback((): void => {
+  const triggerDownload = useCallback((format: DownloadFormat = "txt"): void => {
+    pendingFormatRef.current = format;
     setDownloadRequested((c) => c + 1);
   }, []);
 
   const executeDownload = useCallback((): void => {
-    const blob = generatePromptBlob(filesRef.current);
+    const format = pendingFormatRef.current;
+    const currentFiles = filesRef.current;
+
+    const blob =
+      format === "md"
+        ? generateMarkdownBlob(currentFiles)
+        : generatePromptBlob(currentFiles);
+
+    const filename =
+      format === "md" ? "onefile-prompt.md" : "onefile-prompt.txt";
+
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "onefile-prompt.txt";
+    a.download = filename;
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);

--- a/src/lib/fileStorage.ts
+++ b/src/lib/fileStorage.ts
@@ -1,0 +1,65 @@
+import { FileWithContent } from "@/types";
+
+const DB_NAME = "onefile-storage";
+const STORE_NAME = "files";
+const FILES_KEY = "temp-files";
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore(STORE_NAME);
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function saveFiles(files: FileWithContent[]): Promise<void> {
+  const db = await openDB();
+  const tx = db.transaction(STORE_NAME, "readwrite");
+  tx.objectStore(STORE_NAME).put(files, FILES_KEY);
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => {
+      db.close();
+      resolve();
+    };
+    tx.onerror = () => {
+      db.close();
+      reject(tx.error);
+    };
+  });
+}
+
+export async function loadFiles(): Promise<FileWithContent[] | null> {
+  const db = await openDB();
+  const tx = db.transaction(STORE_NAME, "readonly");
+  const request = tx.objectStore(STORE_NAME).get(FILES_KEY);
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => {
+      db.close();
+      const result = request.result as FileWithContent[] | undefined;
+      resolve(result && Array.isArray(result) && result.length > 0 ? result : null);
+    };
+    request.onerror = () => {
+      db.close();
+      reject(request.error);
+    };
+  });
+}
+
+export async function clearFiles(): Promise<void> {
+  const db = await openDB();
+  const tx = db.transaction(STORE_NAME, "readwrite");
+  tx.objectStore(STORE_NAME).delete(FILES_KEY);
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => {
+      db.close();
+      resolve();
+    };
+    tx.onerror = () => {
+      db.close();
+      reject(tx.error);
+    };
+  });
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,11 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function formatBytes(bytes: number, decimals = 1): string {
+  if (bytes === 0) return "0 B"
+  const k = 1024
+  const sizes = ["B", "KB", "MB", "GB"]
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(decimals))} ${sizes[i]}`
+}

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -427,11 +427,26 @@ export const processEntry = async (entry: FileSystemEntry, path: string = ''): P
 }
 
 export const generatePromptText = (files: FileWithContent[]): string => {
-  let result = '======== FILES ========\n'
-  files.forEach(file => {
-    result += `*** ${file.path} ***\n${file.content}\n\n`
-  })
-  return result
+  const parts = files.map(file => `*** ${file.path} ***\n${file.content}\n\n`)
+  return '======== FILES ========\n' + parts.join('')
+}
+
+export const generatePromptBlob = (files: FileWithContent[]): Blob => {
+  const parts: string[] = ['======== FILES ========\n']
+  for (const file of files) {
+    parts.push(`*** ${file.path} ***\n${file.content}\n\n`)
+  }
+  return new Blob(parts, { type: 'text/plain' })
+}
+
+export const calculateOutputSize = (files: FileWithContent[]): number => {
+  const HEADER_LEN = '======== FILES ========\n'.length
+  let size = HEADER_LEN
+  for (const file of files) {
+    // *** {path} ***\n{content}\n\n
+    size += 4 + file.path.length + 4 + file.content.length + 2
+  }
+  return size
 }
 
 // Compute SHA-256 hash of file content for duplicate detection

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -449,6 +449,49 @@ export const calculateOutputSize = (files: FileWithContent[]): number => {
   return size
 }
 
+const EXTENSION_TO_LANG: Record<string, string> = {
+  '.js': 'javascript', '.jsx': 'jsx', '.ts': 'typescript', '.tsx': 'tsx',
+  '.py': 'python', '.java': 'java', '.rb': 'ruby', '.php': 'php',
+  '.go': 'go', '.rs': 'rust', '.c': 'c', '.cpp': 'cpp', '.h': 'c',
+  '.cs': 'csharp', '.swift': 'swift', '.kt': 'kotlin', '.kts': 'kotlin',
+  '.scala': 'scala', '.groovy': 'groovy', '.dart': 'dart', '.lua': 'lua',
+  '.ex': 'elixir', '.exs': 'elixir', '.r': 'r', '.pl': 'perl',
+  '.sh': 'bash', '.bash': 'bash', '.zsh': 'zsh', '.fish': 'fish',
+  '.html': 'html', '.htm': 'html', '.css': 'css', '.scss': 'scss',
+  '.sass': 'sass', '.less': 'less', '.json': 'json', '.xml': 'xml',
+  '.yaml': 'yaml', '.yml': 'yaml', '.graphql': 'graphql', '.gql': 'graphql',
+  '.sql': 'sql', '.md': 'markdown', '.markdown': 'markdown',
+  '.tex': 'latex', '.bib': 'bibtex', '.bibtex': 'bibtex',
+  '.toml': 'toml', '.ini': 'ini', '.tf': 'hcl', '.tfvars': 'hcl',
+  '.hcl': 'hcl', '.proto': 'protobuf', '.prisma': 'prisma',
+  '.vue': 'vue', '.svelte': 'svelte', '.astro': 'astro',
+  '.dockerfile': 'dockerfile', '.ps1': 'powershell', '.psm1': 'powershell',
+  '.bat': 'batch', '.cmd': 'batch', '.csv': 'csv', '.tsv': 'tsv',
+  '.env': 'dotenv', '.gitignore': 'gitignore', '.dockerignore': 'dockerignore',
+}
+
+function getLang(filePath: string): string {
+  const ext = '.' + filePath.split('.').pop()?.toLowerCase()
+  return EXTENSION_TO_LANG[ext] || ''
+}
+
+export const generateMarkdownText = (files: FileWithContent[]): string => {
+  const parts = files.map(file => {
+    const lang = getLang(file.path)
+    return `## ${file.path}\n\n\`\`\`${lang}\n${file.content}\n\`\`\`\n`
+  })
+  return '# Files\n\n' + parts.join('\n')
+}
+
+export const generateMarkdownBlob = (files: FileWithContent[]): Blob => {
+  const parts: string[] = ['# Files\n\n']
+  for (const file of files) {
+    const lang = getLang(file.path)
+    parts.push(`## ${file.path}\n\n\`\`\`${lang}\n${file.content}\n\`\`\`\n\n`)
+  }
+  return new Blob(parts, { type: 'text/markdown' })
+}
+
 // Compute SHA-256 hash of file content for duplicate detection
 export async function getFileHash(file: File): Promise<string> {
   const buffer = await file.arrayBuffer();


### PR DESCRIPTION
## Summary

- **Fix memory crash on large uploads**: Replaced sessionStorage (5-10MB cap) with
IndexedDB for file persistence, eliminating `RangeError: Invalid string length` crashes when processing large folders (250+ files, 1.5GB+).
- **Blob-based output generation**: Download now uses `Blob` from parts instead of building a single concatenated string, bypassing V8's ~512MB string limit entirely.
- **Truncated preview**: Large outputs show a 50KB preview with file count and total size indicator, preventing browser freeze from rendering millions of characters in the DOM.
- **Markdown download option**: Download button now has a dropdown with `.txt` (default) and `.md` formats. Markdown output uses `##` headings for file paths and fenced code blocks with correct language identifiers.
- **Fix manifest.json 404**: Added missing `public/manifest.json` that was referenced in layout.tsx but never created.

## Credit

Thanks to [Sergey Sanovich](https://www.hoover.org/profiles/sergey-sanovich) for catching the large upload crash and sending detailed logs that made it easy to diagnose. He's also the one who suggested adding the .md download!

## Files changed

- `src/lib/fileStorage.ts` (new) - IndexedDB wrapper for file persistence
- `src/hooks/useFileManager.ts` - Debounced IndexedDB sync replaces sessionStorage
- `src/hooks/useGitHubBrowser.ts` - IndexedDB for OAuth file preservation
- `src/hooks/usePromptOutput.ts` - Lazy generation, size-aware copy, format-aware download
- `src/utils/files.ts` - Array.join fix, Blob generation, markdown output, size calculation
- `src/components/ToolSection.tsx` - Download dropdown, truncation indicator, break-all preview
- `src/lib/utils.ts` - formatBytes utility
- `public/manifest.json` (new) - PWA manifest