### PR TITLE
feat: add Go template file extensions and ignore Rust build directory

### DIFF
--- a/src/constants/files.ts
+++ b/src/constants/files.ts
@@ -15,6 +15,8 @@ export const ALLOWED_EXTENSIONS = new Set([
   '.pug', '.jade', '.haml', '.ejs', '.hbs', '.mustache',
   '.gradle', '.maven', '.pom', '.sbt', '.rake',
   '.gitignore', '.dockerignore', '.editorconfig',
+  // go template files extention
+' .tmpl','.tpl','.gotmpl',
   // Shell and script files
   '.ps1', '.psm1', '.bat', '.cmd', '.vbs', '.awk', '.sed',
   // Document formats
@@ -126,6 +128,8 @@ export const IGNORED_PATHS = new Set([
   'build',
   '.next',
   'out',
+ //rust compilation file
+  'target',
   // Cache directories
   '.cache',
   '__pycache__',


### PR DESCRIPTION
## Summary
This PR enhances file handling by adding support for Go template file extensions and improving directory filtering for Rust projects.

## Changes
- Added Go template file extensions:
  - `.tmpl`
  - `.tpl`
  - `.gotmpl`
- Updated allowed extensions list to include Go templating files
- Added Rust build directory (`target/`) to ignored paths to avoid unnecessary processing

## Motivation
- Enable proper support for Go template files commonly used in Go projects
- Improve performance and reduce noise by excluding compiled Rust artifacts