### PR TITLE
(feat) rename output onefile

### DIFF
--- a/src/components/ToolSection.tsx
+++ b/src/components/ToolSection.tsx
@@ -74,7 +74,7 @@ function EditableFileName({
       <span className="truncate text-sm font-mono text-primary/90">
         {sanitizeBaseFileName(value)}
       </span>
-      <Pencil className="h-3 w-3 shrink-0 text-primary/70 animate-pulse motion-reduce:animate-none" />
+      <Pencil className="h-3.5 w-3.5 shrink-0 text-primary/70 animate-pulse motion-reduce:animate-none" />
     </button>
   );
 }

--- a/src/components/ToolSection.tsx
+++ b/src/components/ToolSection.tsx
@@ -37,6 +37,8 @@ export function ToolSection() {
     triggerDownload,
     executeDownload,
     downloadRequested,
+    baseFileName,
+    setBaseFileName,
   } = usePromptOutput(files);
   const {
     isGitHubBrowserOpen,
@@ -75,8 +77,8 @@ export function ToolSection() {
   return (
     <>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-7">
-        <div className="space-y-4 sm:space-y-6">
-          <div className="bg-card rounded-2xl border border-border shadow-sm p-4 sm:p-8">
+        <div className="h-full">
+          <div className="h-full flex flex-col bg-card rounded-2xl border border-border shadow-sm p-4 sm:p-8">
             <div className="flex items-center gap-3 mb-4 sm:mb-6">
               <div className="p-2 rounded-lg bg-primary/10">
                 <FileText className="h-4 w-4 sm:h-5 sm:w-5 text-primary" />
@@ -127,8 +129,8 @@ export function ToolSection() {
           </div>
         </div>
 
-        <div className="space-y-4 sm:space-y-6">
-          <div className="bg-card rounded-2xl border border-border shadow-sm p-4 sm:p-8">
+        <div className="h-full">
+          <div className="h-full flex flex-col bg-card rounded-2xl border border-border shadow-sm p-4 sm:p-8">
             <div className="flex items-center gap-3 mb-4 sm:mb-6">
               <div className="p-2 rounded-lg bg-primary/10">
                 <Sparkles className="h-4 w-4 sm:h-5 sm:w-5 text-primary" />
@@ -136,14 +138,16 @@ export function ToolSection() {
               <h2 className="text-xl sm:text-2xl font-semibold text-card-foreground">
                 Your One File
               </h2>
-              <a
-                href="https://github.com/wahibonae/onefile"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="hidden sm:inline-flex items-center gap-1.5 bg-muted/60 hover:bg-muted text-muted-foreground text-xs px-2.5 py-1 rounded-full font-medium transition-colors"
-              >
-                Open Source
-              </a>
+              <div className="ml-auto flex items-center">
+                <input
+                  type="text"
+                  value={baseFileName}
+                  onChange={(e) => setBaseFileName(e.target.value)}
+                  className="bg-muted/30 hover:bg-muted/50 border border-border text-sm rounded-lg px-3 py-1.5 text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all w-32 sm:w-48 placeholder:text-muted-foreground/50 h-9"
+                  placeholder="onefile-prompt"
+                  title="Output file name"
+                />
+              </div>
             </div>
 
             <div className="space-y-4 sm:space-y-6">

--- a/src/components/ToolSection.tsx
+++ b/src/components/ToolSection.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Copy, FileText, Download, ChevronDown, File } from "lucide-react";
+import { Copy, FileText, Download, ChevronDown, File, Pencil } from "lucide-react";
 import Sparkles from "@/components/icons/Sparkles";
 import { FileUpload } from "@/components/FileUpload";
 import { FileList } from "@/components/FileList";
@@ -18,12 +18,66 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useFileManager } from "@/hooks/useFileManager";
-import { usePromptOutput } from "@/hooks/usePromptOutput";
+import { usePromptOutput, sanitizeBaseFileName } from "@/hooks/usePromptOutput";
 import { useGitHubBrowser } from "@/hooks/useGitHubBrowser";
 import { useTextContentDialog } from "@/hooks/useTextContentDialog";
 import { useDragAndDrop } from "@/hooks/useDragAndDrop";
 
 const HIGHLIGHTS = ["Download as Markdown", "OneFile is now 10x faster"];
+
+// Click-to-edit output file name, shown as an accent chip in the output card
+// header. Resting state shows the sanitized name; editing keeps the same chip
+// styling. A pulsing pencil hints it can be renamed.
+function EditableFileName({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (name: string) => void;
+}): React.ReactElement {
+  const [editing, setEditing] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function startEditing(): void {
+    setEditing(true);
+    requestAnimationFrame(() => inputRef.current?.select());
+  }
+
+  if (editing) {
+    return (
+      <div className="ml-auto inline-flex items-center gap-2 rounded-lg bg-primary/5 px-3 py-1.5">
+        <input
+          ref={inputRef}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onBlur={() => setEditing(false)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === "Escape") setEditing(false);
+          }}
+          size={Math.min(Math.max(value.length, 4), 24)}
+          aria-label="Output file name"
+          className="w-auto bg-transparent text-sm font-mono text-primary/90 focus:outline-none"
+        />
+        <Pencil className="h-3.5 w-3.5 shrink-0 text-primary/70 animate-pulse motion-reduce:animate-none" />
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={startEditing}
+      title="Click to rename"
+      aria-label="Rename output file"
+      className="group ml-auto inline-flex max-w-full items-center gap-2 rounded-lg bg-primary/5 px-3 py-1.5 transition-colors hover:bg-primary/10"
+    >
+      <span className="truncate text-sm font-mono text-primary/90">
+        {sanitizeBaseFileName(value)}
+      </span>
+      <Pencil className="h-3 w-3 shrink-0 text-primary/70 animate-pulse motion-reduce:animate-none" />
+    </button>
+  );
+}
 
 export function ToolSection() {
   const { files, handleFiles, removeFile, clearAllFiles, handleGitHubImport } =
@@ -77,8 +131,8 @@ export function ToolSection() {
   return (
     <>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-7">
-        <div className="h-full">
-          <div className="h-full flex flex-col bg-card rounded-2xl border border-border shadow-sm p-4 sm:p-8">
+        <div className="space-y-4 sm:space-y-6">
+          <div className="bg-card rounded-2xl border border-border shadow-sm p-4 sm:p-8">
             <div className="flex items-center gap-3 mb-4 sm:mb-6">
               <div className="p-2 rounded-lg bg-primary/10">
                 <FileText className="h-4 w-4 sm:h-5 sm:w-5 text-primary" />
@@ -129,8 +183,8 @@ export function ToolSection() {
           </div>
         </div>
 
-        <div className="h-full">
-          <div className="h-full flex flex-col bg-card rounded-2xl border border-border shadow-sm p-4 sm:p-8">
+        <div className="space-y-4 sm:space-y-6">
+          <div className="bg-card rounded-2xl border border-border shadow-sm p-4 sm:p-8">
             <div className="flex items-center gap-3 mb-4 sm:mb-6">
               <div className="p-2 rounded-lg bg-primary/10">
                 <Sparkles className="h-4 w-4 sm:h-5 sm:w-5 text-primary" />
@@ -138,16 +192,12 @@ export function ToolSection() {
               <h2 className="text-xl sm:text-2xl font-semibold text-card-foreground">
                 Your One File
               </h2>
-              <div className="ml-auto flex items-center">
-                <input
-                  type="text"
+              {finalPrompt && (
+                <EditableFileName
                   value={baseFileName}
-                  onChange={(e) => setBaseFileName(e.target.value)}
-                  className="bg-muted/30 hover:bg-muted/50 border border-border text-sm rounded-lg px-3 py-1.5 text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all w-32 sm:w-48 placeholder:text-muted-foreground/50 h-9"
-                  placeholder="onefile-prompt"
-                  title="Output file name"
+                  onChange={setBaseFileName}
                 />
-              </div>
+              )}
             </div>
 
             <div className="space-y-4 sm:space-y-6">

--- a/src/hooks/usePromptOutput.ts
+++ b/src/hooks/usePromptOutput.ts
@@ -25,6 +25,8 @@ interface UsePromptOutputReturn {
   triggerDownload: (format?: DownloadFormat) => void;
   executeDownload: () => void;
   downloadRequested: number;
+  baseFileName: string;
+  setBaseFileName: (name: string) => void;
 }
 
 function buildPreview(files: FileWithContent[], limit: number): string {
@@ -50,6 +52,7 @@ export function usePromptOutput(
   const [outputSize, setOutputSize] = useState(0);
   const [isTruncated, setIsTruncated] = useState(false);
   const [downloadRequested, setDownloadRequested] = useState(0);
+  const [baseFileName, setBaseFileName] = useState("onefile-prompt");
 
   const filesRef = useRef(files);
   filesRef.current = files;
@@ -114,7 +117,7 @@ export function usePromptOutput(
         : generatePromptBlob(currentFiles);
 
     const filename =
-      format === "md" ? "onefile-prompt.md" : "onefile-prompt.txt";
+      format === "md" ? `${baseFileName}.md` : `${baseFileName}.txt`;
 
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
@@ -124,7 +127,7 @@ export function usePromptOutput(
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
-  }, []);
+  }, [baseFileName]);
 
   return {
     finalPrompt,
@@ -135,5 +138,7 @@ export function usePromptOutput(
     triggerDownload,
     executeDownload,
     downloadRequested,
+    baseFileName,
+    setBaseFileName,
   };
 }

--- a/src/hooks/usePromptOutput.ts
+++ b/src/hooks/usePromptOutput.ts
@@ -13,6 +13,7 @@ import { formatBytes } from "@/lib/utils";
 
 const PREVIEW_LIMIT = 50_000; // ~50KB preview
 const COPY_SIZE_LIMIT = 100 * 1024 * 1024; // 100MB safety guard for clipboard
+const DEFAULT_BASE_FILENAME = "onefile-prompt";
 
 export type DownloadFormat = "txt" | "md";
 
@@ -27,6 +28,21 @@ interface UsePromptOutputReturn {
   downloadRequested: number;
   baseFileName: string;
   setBaseFileName: (name: string) => void;
+}
+
+// Turn user input into a safe download filename: strip path separators and
+// characters illegal on common filesystems, drop a redundant extension, trim
+// leading/trailing dots and spaces, and cap the length. Hyphens, underscores
+// and inner spaces are kept since they are valid. Falls back to the default
+// when nothing usable remains.
+export function sanitizeBaseFileName(raw: string): string {
+  const cleaned = raw
+    .replace(/[/\\:*?"<>|]/g, "")
+    .replace(/\.(txt|md)$/i, "")
+    .replace(/^[.\s]+/, "")
+    .slice(0, 100)
+    .replace(/[.\s]+$/, "");
+  return cleaned || DEFAULT_BASE_FILENAME;
 }
 
 function buildPreview(files: FileWithContent[], limit: number): string {
@@ -52,7 +68,7 @@ export function usePromptOutput(
   const [outputSize, setOutputSize] = useState(0);
   const [isTruncated, setIsTruncated] = useState(false);
   const [downloadRequested, setDownloadRequested] = useState(0);
-  const [baseFileName, setBaseFileName] = useState("onefile-prompt");
+  const [baseFileName, setBaseFileName] = useState(DEFAULT_BASE_FILENAME);
 
   const filesRef = useRef(files);
   filesRef.current = files;
@@ -116,8 +132,8 @@ export function usePromptOutput(
         ? generateMarkdownBlob(currentFiles)
         : generatePromptBlob(currentFiles);
 
-    const filename =
-      format === "md" ? `${baseFileName}.md` : `${baseFileName}.txt`;
+    const safeName = sanitizeBaseFileName(baseFileName);
+    const filename = format === "md" ? `${safeName}.md` : `${safeName}.txt`;
 
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");


### PR DESCRIPTION
There was no option to name the one file as it always saved as onefile-prompt (9).md or onefile-prompt (5).txt
which was annoying and made things unorganized 
added feature to rename output OneFile and made some aesthetic improvements 
Both the div class are now of same height

Please accept my pull request